### PR TITLE
Patch 1

### DIFF
--- a/evals.py
+++ b/evals.py
@@ -1,8 +1,8 @@
 import tensorflow as tf
 from problems.adding_problem import AddingProblemDataset
 from problems.copying_memory_problem import CopyingMemoryProblemDataset
-from networks.tf_rnn import TFRNN
-from networks.urnn_cell import URNNCell
+from models.tf_rnn import TFRNN
+from models.urnn_cell import URNNCell
 import numpy as np
 
 '''

--- a/mnist_evals.py
+++ b/mnist_evals.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 from problems.mnist import MnistProblemDataset
-from networks.tf_rnn import TFRNN
-from networks.urnn_cell import URNNCell
+from models.tf_rnn import TFRNN
+from models.urnn_cell import URNNCell
 import numpy as np
 
 loss_path='mnist_results/'


### PR DESCRIPTION
In the eval scripts, `TFNN` and `URNNCell` were imported from `networks`.

This was throwing a module import error.

Fixed by importing these from `models`